### PR TITLE
Add support for keepalive interval

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -16,6 +16,7 @@ Configuration fields:
 - Password (only used with password-based auth): Password to use to authenticate with the remote server.
 - Full path to Private Key file on local system (key-based authentication): Full path on local system to the private key file. Note: This only used when you want to use key-based authentication instead of a password.
 - Passphrase (key-based authentication): Passphrase to use to decrypt the private key (if private key encryption was used when the key was generated)
+- Keepalive Interval (in ms): Interval in ms to send ssh keepalive messages to ensure the connection doesn't close. Set to 0 to disable.
 
 ### Action Usage
 

--- a/main.js
+++ b/main.js
@@ -53,18 +53,19 @@ class SSHInstance extends InstanceBase {
 			}
 
 			// setup the needed parameters for the SSH client connection
-			const authConfig = {
+			const clientConfig = {
 				host: this.config.host,
 				port: this.config.port,
 				username: this.config.username,
 				password: this.config.password,
 				privateKey: loadedPrivateKey,
 				passphrase: this.config.passphrase,
+				keepaliveInterval: this.config.keepaliveInterval,
 			}
 
 			try {
 				// initiate the SSH client connection
-				this.sshClient.connect(authConfig)
+				this.sshClient.connect(clientConfig)
 			} catch (err) {
 				this.log('error', 'initiating connection failed, error: ' + err)
 				this.updateStatus(InstanceStatus.ConnectionFailure)
@@ -165,6 +166,14 @@ class SSHInstance extends InstanceBase {
 				id: 'passphrase',
 				label: 'Passphrase (key-based authentication)',
 				width: 6,
+			},
+			{
+				type: 'textinput',
+				id: 'keepaliveInterval',
+				label: 'Keepalive Interval in ms',
+				width: 6,
+				regex: Regex.NUMBER,
+				default: 0,
 			},
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"main": "main.js",
 	"scripts": {
 		"format": "prettier -w .",
-		"postinstall": "rimraf node_modules/ssh2/lib/protocol/crypto/build node_modules/cpu-features"
+		"postinstall": "rimraf node_modules/ssh2/lib/protocol/crypto/build node_modules/cpu-features",
+		"package": "companion-module-build"
 	},
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
**Describe the feature**
For long lasting ssh sessions it would be good to ensure, that the ssh session does not close if not much is happening there. The keepalive feature is intended for exactly this, so would be good to if it could be enabled.

**Usecases**
Have long lasting ssh connections with not that many commands.