### PR TITLE
Added preferred algorithms

### DIFF
--- a/algorithms.js
+++ b/algorithms.js
@@ -1,0 +1,34 @@
+
+const Ciphers = {
+  AUTO: 0,
+  AES256: 1,
+}
+
+function createAlgorithmsObjectForSSH2(config) {
+  let algorithms = undefined;
+
+  switch (config.preferedCipher) {
+    case Ciphers.AUTO:
+      break;
+    case Ciphers.AES256:
+      algorithms = {
+        // cipher: [
+        //   "aes256-gcm"
+        // ]
+        cipher: { 
+          prepend: new RegExp(/aes256\-gcm/)
+        }
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return algorithms;
+}
+
+module.exports = {
+  Ciphers,
+  createAlgorithmsObjectForSSH2
+}

--- a/algorithms.js
+++ b/algorithms.js
@@ -2,27 +2,34 @@
 const Ciphers = {
 	AUTO: 0,
 	AES256: 1,
+	AES192: 2,
+	AES128: 3,
 }
 
 function createAlgorithmsObjectForSSH2(config) {
-	let algorithms = undefined;
+	let regex = undefined;
 
 	switch (config.preferedCipher) {
 		case Ciphers.AUTO:
-			break;
-		case Ciphers.AES256:
-			algorithms = {
-				cipher: { 
-					prepend: new RegExp(/aes256\-gcm/)
-				}
-			}
-			break;
-
+			return undefined;
+			case Ciphers.AES256:
+				regex = new RegExp(/aes256/)
+				break;
+			case Ciphers.AES192:
+				regex = new RegExp(/aes192/)
+				break;
+			case Ciphers.AES128:
+				regex = new RegExp(/aes128/)
+				break;
 		default:
 			break;
 	}
 
-	return algorithms;
+	return {
+		cipher: { 
+			prepend: regex
+		}
+	}
 }
 
 module.exports = {

--- a/algorithms.js
+++ b/algorithms.js
@@ -1,34 +1,31 @@
 
 const Ciphers = {
-  AUTO: 0,
-  AES256: 1,
+	AUTO: 0,
+	AES256: 1,
 }
 
 function createAlgorithmsObjectForSSH2(config) {
-  let algorithms = undefined;
+	let algorithms = undefined;
 
-  switch (config.preferedCipher) {
-    case Ciphers.AUTO:
-      break;
-    case Ciphers.AES256:
-      algorithms = {
-        // cipher: [
-        //   "aes256-gcm"
-        // ]
-        cipher: { 
-          prepend: new RegExp(/aes256\-gcm/)
-        }
-      }
-      break;
+	switch (config.preferedCipher) {
+		case Ciphers.AUTO:
+			break;
+		case Ciphers.AES256:
+			algorithms = {
+				cipher: { 
+					prepend: new RegExp(/aes256\-gcm/)
+				}
+			}
+			break;
 
-    default:
-      break;
-  }
+		default:
+			break;
+	}
 
-  return algorithms;
+	return algorithms;
 }
 
 module.exports = {
-  Ciphers,
-  createAlgorithmsObjectForSSH2
+	Ciphers,
+	createAlgorithmsObjectForSSH2
 }

--- a/main.js
+++ b/main.js
@@ -192,6 +192,14 @@ class SSHInstance extends InstanceBase {
 						id: algorithms.Ciphers.AES256,
 						label: 'AES256',
 					},
+					{
+						id: algorithms.Ciphers.AES192,
+						label: 'AES192',
+					},
+					{
+						id: algorithms.Ciphers.AES128,
+						label: 'AES128',
+					},
 				],
 			},
 		]

--- a/main.js
+++ b/main.js
@@ -62,7 +62,7 @@ class SSHInstance extends InstanceBase {
 				privateKey: loadedPrivateKey,
 				passphrase: this.config.passphrase,
 				keepaliveInterval: this.config.keepaliveInterval,
-        algorithms: algorithms.createAlgorithmsObjectForSSH2(this.config),
+				algorithms: algorithms.createAlgorithmsObjectForSSH2(this.config),
 			}
 
 			try {
@@ -184,15 +184,15 @@ class SSHInstance extends InstanceBase {
 				width: 6,
 				default: algorithms.Ciphers.AUTO,
 				choices: [
-          {
-            id: algorithms.Ciphers.AUTO,
-            label: 'Auto'
-          },
-          {
-            id: algorithms.Ciphers.AES256,
-            label: 'AES256',
-          },
-        ],
+					{
+						id: algorithms.Ciphers.AUTO,
+						label: 'Auto'
+					},
+					{
+						id: algorithms.Ciphers.AES256,
+						label: 'AES256',
+					},
+				],
 			},
 		]
 	}

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const UpdateFeedbacks = require('./feedbacks')
 const UpdateVariableDefinitions = require('./variables')
 const ssh = require('ssh2')
 const fs = require('fs')
+const algorithms = require('./algorithms')
 
 const Constants = {
 	CMD_ERROR_VAR_NAME: 'returnedError',
@@ -61,6 +62,7 @@ class SSHInstance extends InstanceBase {
 				privateKey: loadedPrivateKey,
 				passphrase: this.config.passphrase,
 				keepaliveInterval: this.config.keepaliveInterval,
+        algorithms: algorithms.createAlgorithmsObjectForSSH2(this.config),
 			}
 
 			try {
@@ -110,7 +112,7 @@ class SSHInstance extends InstanceBase {
 			})
 
 			this.sshClient.on('handshake', (negotiated) => {
-				this.log('debug', 'Server handshake: ' + negotiated)
+				this.log('debug', 'Server handshake: ' + JSON.stringify(negotiated))
 			})
 		}
 	}
@@ -174,6 +176,23 @@ class SSHInstance extends InstanceBase {
 				width: 6,
 				regex: Regex.NUMBER,
 				default: 0,
+			},
+			{
+				type: 'dropdown',
+				id: 'preferedCipher',
+				label: 'Prefered Cipher Methods',
+				width: 6,
+				default: algorithms.Ciphers.AUTO,
+				choices: [
+          {
+            id: algorithms.Ciphers.AUTO,
+            label: 'Auto'
+          },
+          {
+            id: algorithms.Ciphers.AES256,
+            label: 'AES256',
+          },
+        ],
 			},
 		]
 	}


### PR DESCRIPTION
This PR adds a dropdown menu for a preferred cipher algorithm to connect to a ssh server.

It adds an extra module for generating the algorithm object which can be attached to the clientConfig.
